### PR TITLE
:wrench: Wrap install.bat with better management of stdout

### DIFF
--- a/resources/output_limit.vbs
+++ b/resources/output_limit.vbs
@@ -1,0 +1,36 @@
+Function ExecCommand(cmd)
+    Const WshRunning = 0
+    Const WshFinished = 1
+
+    Dim objWshShell : Set objWshShell = CreateObject("WScript.Shell")
+    Dim oExec : Set oExec = objWshShell.Exec(cmd)
+    Dim outputText
+    Do
+        'sleep in the loop before reading pipelines and reading finished state
+        WScript.Sleep 50
+
+        ' We must read these, or it seems to block execution after 700 lines out output,
+        ' probably because VBScript is blocking the pipeline, because script completes if VBScirpt is stoped with Ctrl-C
+        While oExec.StdOut.AtEndOfStream <> True
+            outputText = oExec.StdOut.ReadLine()
+            For i = 1 To Len(outputText) - 1 Step 1024
+                WScript.StdOut.WriteLine(Mid(outputText, i, 1024))
+            next
+        Wend
+
+        While oExec.StdErr.AtEndOfStream <> True
+            outputText = oExec.StdErr.ReadLine()
+            WScript.StdErr.Write("ERROR: ")
+            For i = 1 To Len(outputText) - 1 Step 1024
+                WScript.StdErr.WriteLine(Mid(outputText, i, 1024))
+            next
+        Wend
+
+        Finished = ( oExec.Status = WshFinished )
+    Loop Until Finished
+    
+    WScript.StdOut.WriteLine("ExitCode: " & oExec.ExitCode)
+    WScript.Quit(oExec.ExitCode) ' Optionally sets exit-code and exits this VbScript (but does not stop the executing sub-shell)
+End Function
+
+ExecCommand(WScript.Arguments.Item(0))

--- a/scripts/headers/install_backend.nsh
+++ b/scripts/headers/install_backend.nsh
@@ -14,6 +14,7 @@
     File "${SOURCE_DIR}\environment.yml"
     File "${SOURCE_DIR}\install.bat"
     File "${SOURCE_DIR}\run_server.bat"
+    File "${SOURCE_DIR}\output_limit.vbs"
     File /r "${SOURCE_DIR}\api\*.*"
 
     ; Install LibreOffice silently in the installation directory
@@ -23,7 +24,7 @@
 
     ; Run the installation batch file
     DetailPrint "Installing backend dependencies..."
-    nsExec::ExecToLog '"$INSTDIR\install.bat"'
+    nsExec::ExecToLog '"cscript.exe" //NOLOGO output_limit.vbs "$INSTDIR\install.bat"'
     
     ; Add 'es-AR' locale and set 'en-US' as default
     nsExec::ExecToLog 'powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-WinSystemLocale"'


### PR DESCRIPTION
on-behalf-of: @dblandit hola@dblandit.com

## Summary by Sourcery

Wrap the backend installation batch file in a VBScript wrapper to chunk and stream its stdout/stderr and prevent NSIS output blocking during installation.

Enhancements:
- Add output_limit.vbs script to execute commands with controlled stdout/stderr streaming and exit-code handling
- Update NSIS installer script to include output_limit.vbs and invoke install.bat via cscript for better output management