### PR TITLE
Update frontend version url

### DIFF
--- a/scripts/headers/install_frontend.nsh
+++ b/scripts/headers/install_frontend.nsh
@@ -1,6 +1,6 @@
 ; Frontend Installation Header
 
-!define FRONTEND_URL "https://github.com/AymurAI/desktop-app/releases/download/v1.23.2/AymurAI-win32-1-23-2.zip"
+!define FRONTEND_URL "https://github.com/AymurAI/desktop-app/releases/download/v1.24.0/AymurAI-win32-1-24-0.zip"
 
 !macro InstallFrontend
     ; Check if frontend is already installed


### PR DESCRIPTION
Updated from 1.23.2 -> 1.24.0

## Summary by Sourcery

Chores:
- Bump download URL in install_frontend.nsh from v1.23.2 to v1.24.0